### PR TITLE
Fix mobile spacing and margins

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -188,7 +188,7 @@ code { background:#010; padding:0 4px; border-radius:3px; }
   .skills-grid { grid-template-columns:1fr; gap:2px; }
   .content-text { max-width:100%; font-size:0.9rem; }
   .content-area {
-    top: 280px;
+    top: 260px;
     max-height: 65vh;
     width: 98vw;
   }
@@ -250,10 +250,15 @@ code { background:#010; padding:0 4px; border-radius:3px; }
     box-shadow: 0 2px 4px rgba(0, 255, 0, 0.2);
   }
   .content-area {
-    top: 400px;
-    max-height: 55vh;
+    top: 300px;
+    max-height: 60vh;
     width: 100vw;
     padding: 0 4px;
+  }
+
+  /* Reduce header block height to minimize blank space above navigation */
+  #resume-content {
+    min-height: 40vh;
   }
   .content-text { font-size:0.85rem; line-height:1.4; }
   .skills-grid { margin:2px 0; }


### PR DESCRIPTION
Adjust mobile CSS to reduce excessive spacing and improve content positioning.

These changes eliminate large blank gaps above and below the navigation bar on phones by adjusting `top` and `max-height` for `.content-area` and `min-height` for `#resume-content` at specific mobile breakpoints.

---

[Open in Web](https://cursor.com/agents?id=bc-7cbeb8c2-10db-4caa-93b4-044a8027bf96) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7cbeb8c2-10db-4caa-93b4-044a8027bf96) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)